### PR TITLE
对replyNotify函数方法的类型声明修正

### DIFF
--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -368,10 +368,10 @@ class PaymentService extends BaseService
 
     /**
      * 回复通知
-     * @param bool $isSuccess 是否成功
-     * @param string $msg 失败原因
+     * @param bool|null $isSuccess 是否成功
+     * @param string|null $msg 失败原因
      */
-    public function replyNotify(bool $isSuccess = true, string $msg = '')
+    public function replyNotify(?bool $isSuccess = true, ?string $msg = '')
     {
         $data = [];
         if ($isSuccess) {


### PR DESCRIPTION
修复后解决默认为null报错$msg must be of type string, null given